### PR TITLE
add makefile, update Top.scala to adapt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+default: c
+executables := $(notdir $(basename $(wildcard src/main/scala/*.scala)))
+c:
+	sbt "run --backend c --compile --genHarness --test --debug --vcd --debugMem --vcdMem"
+# autodetect file changes and rerun
+cc:
+	sbt "~run --backend c --compile --genHarness --test --debug --vcd --debugMem --vcdMem"
+v:
+	sbt "run --backend v --genHarness"
+
+# autodetect file changes and rerun
+vv:
+	sbt "~run --backend v --genHarness"
+
+clean:
+	rm -f $(executables)
+	rm -rf target*
+	rm -rf project/target*
+	rm -f *.cpp *.h *.o
+
+clean_all:
+	rm -f $(executables)
+	rm -rf target*
+	rm -rf project/target*
+	rm -f *.cpp *.h *.o
+	rm -f *.vcd *.v	
+
+.PHONY: all c cc v vv clean clean_all

--- a/src/main/scala/Top.scala
+++ b/src/main/scala/Top.scala
@@ -43,9 +43,8 @@ class TopTests(c: Top) extends Tester(c) {
 
 object Top {
   def main(args: Array[String]): Unit = {
-    val tutArgs = args.slice(1, args.length)
     args.foreach(arg => println(arg))
-    chiselMainTest(tutArgs, () => Module(new Top())) {
+    chiselMainTest(args, () => Module(new Top())) {
       c => new TopTests(c) }
   }
 }


### PR DESCRIPTION
Usage: 
- `make`
  - default to `make c`
- `make c`
  - generate simulation binaries
  - or use `make cc` to automatically rerun
- `make vv`
  - generate verilog files
  - use `make vv` to automatically rerun
- `make clean`
  - clean all files except .v and .vcd
- `make clean_all`
  - clean all generated files
